### PR TITLE
Added depth query param to limit the depth of returned page tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ target/
 /toolchain-fitnesse-plugin-test/wiki/FitNesseRoot/files/downloads
 /toolchain-fitnesse-plugin-test/wiki/FitNesseRoot/files/pagesources
 /toolchain-fitnesse-plugin-test/wiki/fitnesse-standalone.jar
+
+.vscode/

--- a/toolchain-fitnesse-plugin/pom.xml
+++ b/toolchain-fitnesse-plugin/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>nl.praegus</groupId>
             <artifactId>fitnesse-bootstrap-plus-theme</artifactId>
-            <version>2.0.16</version>
+            <version>2.0.17-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>nl.praegus</groupId>

--- a/toolchain-fitnesse-plugin/src/main/java/nl/praegus/fitnesse/responders/TableOfContentsResponder.java
+++ b/toolchain-fitnesse-plugin/src/main/java/nl/praegus/fitnesse/responders/TableOfContentsResponder.java
@@ -20,11 +20,17 @@ import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 
 import static nl.praegus.fitnesse.responders.WikiPageHelper.loadPage;
 
 public class TableOfContentsResponder implements SecureResponder {
 
+    public static final String SUITE_CLASS = "suite";
+    public static final String TEST_CLASS = "test";
+    public static final String STATIC_CLASS = "static";
+    public static final String LINKED_CLASS = " linked";
+    public static final String PRUNED_CLASS = " pruned";
     private static final String NAME = "name";
     private static final String TYPE = "type";
     private static final String HELP = "help";
@@ -32,23 +38,32 @@ public class TableOfContentsResponder implements SecureResponder {
     private static final String TAGS = "tags";
     private static final String PATH = "path";
     private static final String CHILDREN = "children";
-    public static final String SUITE_CLASS = "suite";
-    public static final String TEST_CLASS = "test";
-    public static final String STATIC_CLASS = "static";
-    public static final String LINKED_CLASS = " linked";
-    public static final String PRUNED_CLASS = " pruned";
-
+    private static final String DEPTH_PARAM = "depth";
     private final JSONArray tableOfContents = new JSONArray();
 
     @Override
     public Response makeResponse(FitNesseContext fitNesseContext, Request request) throws Exception {
         WikiSourcePage sourcePage = new WikiSourcePage(loadPage(fitNesseContext, request.getResource(), request.getMap()));
+        Optional<Integer> maxDepth = getMaxDepthFromRequest(request);
 
-        return makeTableOfContentsResponse(sourcePage);
+        return makeTableOfContentsResponse(sourcePage, maxDepth);
     }
 
-    private SimpleResponse makeTableOfContentsResponse(SourcePage sourcePage) throws UnsupportedEncodingException {
-        tableOfContents.put(getPageInfo(null, sourcePage));
+    private Optional<Integer> getMaxDepthFromRequest(Request request) {
+        String depthParam = request.getInput(DEPTH_PARAM);
+        if (depthParam != null) {
+            try {
+                return Optional.of(Integer.parseInt(depthParam));
+            } catch (NumberFormatException e) {
+                // If the depth parameter is not a valid integer, return empty Optional
+                return Optional.empty();
+            }
+        }
+        return Optional.empty(); // Return empty Optional when no depth parameter is present
+    }
+
+    private SimpleResponse makeTableOfContentsResponse(SourcePage sourcePage, Optional<Integer> maxDepth) throws UnsupportedEncodingException {
+        tableOfContents.put(getPageInfo(null, sourcePage, maxDepth, 0));
         SimpleResponse response = new SimpleResponse();
         response.setMaxAge(0);
         response.setStatus(200);
@@ -64,7 +79,7 @@ public class TableOfContentsResponder implements SecureResponder {
         return result;
     }
 
-    private JSONObject getPageInfo(SourcePage parent, SourcePage page) {
+    private JSONObject getPageInfo(SourcePage parent, SourcePage page, Optional<Integer> maxDepth, int currentDepth) {
         JSONObject pageInfo = new JSONObject();
         pageInfo.put(NAME, GracefulNamer.regrace(page.getName()));
         pageInfo.put(TYPE, getBooleanPropertiesClasses(page));
@@ -74,15 +89,19 @@ public class TableOfContentsResponder implements SecureResponder {
         pageInfo.put(IS_SYMLINK, parent instanceof WikiSourcePage && ((WikiSourcePage) parent).hasSymbolicLinkChild(page.getName()));
 
         for (String tag : tags) {
-            if (tag.length() > 0) {
+            if (!tag.isEmpty()) {
                 pageInfo.append(TAGS, tag);
             }
         }
 
         pageInfo.put(PATH, page.getFullPath());
 
-        for (SourcePage p : getSortedChildren(page)) {
-            pageInfo.append(CHILDREN, getPageInfo(page, p));
+        // If maxDepth is not present (empty Optional), or if we haven't reached the maximum depth
+        // then add children
+        if (!maxDepth.isPresent() || currentDepth < maxDepth.get()) {
+            for (SourcePage p : getSortedChildren(page)) {
+                pageInfo.append(CHILDREN, getPageInfo(page, p, maxDepth, currentDepth + 1));
+            }
         }
 
         return pageInfo;

--- a/toolchain-fitnesse-plugin/src/test/java/nl/praegus/fitnesse/symbols/MavenProjectVersions/MavenProjectVersionsSymbolTest.java
+++ b/toolchain-fitnesse-plugin/src/test/java/nl/praegus/fitnesse/symbols/MavenProjectVersions/MavenProjectVersionsSymbolTest.java
@@ -21,7 +21,7 @@ public class MavenProjectVersionsSymbolTest {
 
         String expectedValue = "<tr><td>fitnesse</td>" + System.lineSeparator() +
                 "<td>20200404</td>" + System.lineSeparator() +
-                "<td>20231203</td>" + System.lineSeparator() +
+                "<td>20250223</td>" + System.lineSeparator() +
                 "<td class=\"Outdated\">Outdated</td>";
 
         String expectedValue2 = "<a href=\"http://fitnesse.org/FitNesse.ReleaseNotes\" target=\"_blank\">fitnesse</a>";


### PR DESCRIPTION
Added functionality to use query param 'depth' to limit the levels of child pages returned in the response. This change makes it possible to implement lazy loading of the sidebar in the bootstrap-plus theme by requesting only a the needed pages.