### PR TITLE
Add nullcheck to release notes info

### DIFF
--- a/toolchain-fitnesse-plugin/src/main/java/nl/praegus/fitnesse/symbols/MavenProjectVersions/MavenProjectVersionsSymbol.java
+++ b/toolchain-fitnesse-plugin/src/main/java/nl/praegus/fitnesse/symbols/MavenProjectVersions/MavenProjectVersionsSymbol.java
@@ -126,10 +126,10 @@ public class MavenProjectVersionsSymbol extends SymbolType implements Rule, Tran
         releaseNotesInfo.forEach(info -> {
             writer.startTag("div");
 
-            if (!info.get("url").isEmpty()) {
+            if (info.get("url")!= null && !info.get("url").isEmpty()) {
                 writeReleaseNotesLink(writer, info);
             }
-            if (info.get("url").isEmpty()) {
+            else {
                 writeReleaseNotesNotFound(writer);
             }
             writer.endTag();


### PR DESCRIPTION
Add nullcheck to release notes info to prevent NPE when rendering with no connection or missing homepage url